### PR TITLE
Made the chokidar watch conditional

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,21 +11,21 @@ function getDependencies(filePath) {
 	let replaceNewLine = function(s) {
 		return s.replace(/\r\n/gm, '\n');
 	};
-	
+
 	let dirname = path.dirname(filePath);
-	
+
 	if (!fs.existsSync(filePath)) {
 		throw new Error("File does not exist: " + filePath);
 	}
 	let source = fs.readFileSync(filePath, "utf-8");
 	source = replaceNewLine(source).replace(/%A_ScriptDir%/gi, dirname);
 	let result = REGEX_INCLUDE.exec(source);
-	
+
 	while (result != null) {
 		let match = result[0];
-		
+
 		let includePath = path.resolve(result[2]);
-		
+
 		if (!fs.existsSync(includePath)) {
 			throw new Error("File does not exist: " + includePath);
 		}
@@ -40,14 +40,9 @@ exports.run = () => {
 	let config = process.argv.slice(2);
 	let entryPath = config[0];
 	entryPath = path.resolve(entryPath);
-	
+
 	let dependencies = getDependencies(entryPath);
 
-	let watcher = chokidar.watch(dependencies, {
-	  ignored: /(^|[\/\\])\../,
-	  persistent: true
-	});
-	
 	function runTests() {
 		let exePath = path.resolve(conf.ahkPath);
 		execFile(exePath, [entryPath], function callback(error, stdout, stderr) {
@@ -56,5 +51,12 @@ exports.run = () => {
 	}
 	runTests();
 
-	watcher.on('change', path => runTests());
+	if (config.includes("watch")) {
+		let watcher = chokidar.watch(dependencies, {
+			ignored: /(^|[\/\\])\../,
+			persistent: true
+		});
+
+		watcher.on('change', path => runTests());
+	}
 }


### PR DESCRIPTION
This change makes the `chokidar.watch` conditional on an argument `watch`.

by doing this, `npm test` will finish (_TBD: return an errorlevel_) so that it can be used as feedback of the tests. UseCase: have a CI fail a job if tests failed.
the previous behavior (have the tests run on each file change) can be used with `npm test watch`